### PR TITLE
Remove mapplus.cn warning from README and zh-Hans welcome letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 请注意，这并非OSM官网而是社区网站<br/>
 OSM官网为<a href="https://openstreetmap.org">https://openstreetmap.org</a>
 </big></big></b></p>
-<p><big>
-此外， osm.mapplus.cn 并非OSM中国社区网站，也非OSM官方网站，您在这个站点做出的所有编辑都不会被同步到OSM。
-</big></p>
 
 <hr/>
 

--- a/pages/welcome/default/zh-Hans.md
+++ b/pages/welcome/default/zh-Hans.md
@@ -15,9 +15,7 @@ OSM官网为<a href="https://openstreetmap.org">https://openstreetmap.org</a>
 </big></big></b></p>
 此处列出的沟通方式亦无法满足“数据下载”、“瓦片下载”或“课设辅导”等需求。<br/>
 如您并非OSM编辑者但通过搜索引擎找到了本站点，可能是搜索引擎错误将您导向了这里。您需要的是尝试访问OSM官方Wiki查阅文档或geofabric等镜像站下载数据。
-<p><big>
-此外， osm.mapplus.cn 并非OSM中国社区网站，也非OSM官方网站，您在这个站点做出的所有编辑都不会被同步到OSM。
-</big></p>
+
 
 ## 欢迎来到OpenStreetMap
 


### PR DESCRIPTION
This PR removes the warning about mapplus.cn from the main README and the zh-Hans welcome letter as requested in issue #5. The warning is no longer needed, but the statement that this is not an official OSM site is retained.

Fixes #5

This PR was created automatically by OpenHands AI assistant.